### PR TITLE
[RCM-1022] Upgrade from upstream (2024-04-03) and cherry pick our changes Celery>=5.2.7

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This file is managed by terraform in the github-infra repo.
+# Changes to this CODEOWNERS file should be done in github-infra.
+
+* @HeadspaceMeditation/care-platform

--- a/django_celery_results/admin.py
+++ b/django_celery_results/admin.py
@@ -11,7 +11,7 @@ class TaskResultAdmin(admin.ModelAdmin):
 
     model = TaskResult
     list_display = ('task_id', 'date_done', 'status')
-    readonly_fields = ('date_done', 'result', 'hidden', 'meta')
+    readonly_fields = ('date_done', 'hidden', 'meta')
     fieldsets = (
         (None, {
             'fields': (
@@ -24,7 +24,6 @@ class TaskResultAdmin(admin.ModelAdmin):
         }),
         ('Result', {
             'fields': (
-                'result',
                 'date_done',
                 'traceback',
                 'hidden',

--- a/django_celery_results/managers.py
+++ b/django_celery_results/managers.py
@@ -110,7 +110,6 @@ class TaskResultManager(models.Manager):
         """
         fields = {
             'status': status,
-            'result': result,
             'traceback': traceback,
             'meta': meta,
             'content_encoding': content_encoding,
@@ -120,7 +119,8 @@ class TaskResultManager(models.Manager):
         if not created:
             for k, v in items(fields):
                 setattr(obj, k, v)
-            obj.save()
+        obj.inflated = result
+        obj.save()
         return obj
 
     def warn_if_repeatable_read(self):

--- a/django_celery_results/migrations/0001_initial.py
+++ b/django_celery_results/migrations/0001_initial.py
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
                     max_length=128, verbose_name='content type')),
                 ('content_encoding', models.CharField(
                     max_length=64, verbose_name='content encoding')),
-                ('result', models.TextField(default=None, editable=False,
+                ('result', models.BinaryField(default=None, editable=False,
                                             null=True)),
                 ('date_done', models.DateTimeField(
                     auto_now=True, verbose_name='done at')),

--- a/django_celery_results/models.py
+++ b/django_celery_results/models.py
@@ -9,6 +9,11 @@ from celery.five import python_2_unicode_compatible
 
 from . import managers
 
+import io
+import gzip
+import logging
+from .utils import disable_logging
+
 ALL_STATES = sorted(states.ALL_STATES)
 TASK_STATE_CHOICES = sorted(zip(ALL_STATES, ALL_STATES))
 
@@ -32,7 +37,10 @@ class TaskResult(models.Model):
     content_encoding = models.CharField(
         _('content encoding'), max_length=64,
     )
-    result = models.TextField(null=True, default=None, editable=False)
+
+    # Warning: access the result via the `inflated` getter/setter which handles gzipping/unzipping,
+    #          do not acccess result data directly.
+    result = models.BinaryField(null=True, default=None, editable=False)
     date_done = models.DateTimeField(_('done at'), auto_now=True)
     traceback = models.TextField(_('traceback'), blank=True, null=True)
     hidden = models.BooleanField(editable=False, default=False, db_index=True)
@@ -50,11 +58,59 @@ class TaskResult(models.Model):
         return {
             'task_id': self.task_id,
             'status': self.status,
-            'result': self.result,
+            'result': self.inflated,
             'date_done': self.date_done,
             'traceback': self.traceback,
             'meta': self.meta,
         }
+
+    @property
+    def inflated(self):
+        """
+        Unzipped result.
+        :return:
+        """
+        if self.result is None:
+            return None
+
+        in_ = io.BytesIO()
+        in_.write(self.result)
+        in_.seek(0)
+        with gzip.GzipFile(fileobj=in_, mode='rb') as fo:
+            gunzipped_bytes_obj = fo.read()
+
+        return gunzipped_bytes_obj.decode('utf-8')
+
+    @inflated.setter
+    def inflated(self, uncompressed):
+        """
+        Gzips the provided uncompressed value into the result field.
+        :param uncompressed: serialized input data
+        :return:
+        """
+        if uncompressed is None:
+            self.result = None
+            return
+
+        # Gzip it for storage.
+        out = io.BytesIO()
+        with gzip.GzipFile(fileobj=out, mode='w') as fo:
+            fo.write(uncompressed.encode('utf-8'))
+        self.result = out.getvalue()
+
+    def save(self, *args, **kwargs):
+        """
+        MySQL django backend issues warnings when BinaryField is sent
+        non text encoded bytes.
+
+        This suppresses these superflous warnings.
+        :param args:
+        :param kwargs:
+        :return:
+        """
+        with disable_logging(logging.WARNING):
+            super(TaskResult, self).save(*args, **kwargs)
+
 
     def __str__(self):
         return '<Task: {0.task_id} ({0.status})>'.format(self)

--- a/django_celery_results/utils.py
+++ b/django_celery_results/utils.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings
 from django.utils import timezone
+import logging
 
 # see Issue celery/django-celery#222
 now_localtime = getattr(timezone, 'template_localtime', timezone.localtime)
@@ -16,3 +17,17 @@ def now():
         return now_localtime(timezone.now())
     else:
         return timezone.now()
+
+class disable_logging(object):
+    """
+    Within block, disable logging at or below the specified level.
+    """
+    def __init__(self, level=logging.WARNING):
+        self.disabled_level = level
+
+    def __enter__(self, *args, **kwargs):
+        logging.disable(self.disabled_level)
+
+    def __exit__(self, *args, **kwargs):
+        logging.disable(logging.NOTSET)
+

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
 case>=1.3.1
 pytest>=3.0
 pytest-django
-pytz>dev
+pytz


### PR DESCRIPTION
https://headspace.atlassian.net/browse/RCM-1022

- Created a `main` branch, and synchronized it with [upstream](https://github.com/celery/django-celery-results) (rev `23265e6c914dc30f8f652dbce098dad6fd761021`)
- branched from that onto dj42 and merged our existing changes onto this one

!Important: this requires celery >=5.2.7

## Usage
```
django-celery-results = {git = "https://github.com/HeadspaceMeditation/django-celery-results.git", branch = "dj42"}
```

## TODO:

- [ ] test and see if we will also need to patch result as BinaryField for the new `GroupResult`
