### PR TITLE
[RCM-1022] Upgrade from upstream (v2.0.1) and cherry pick our changes Celery>=4.4

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This file is managed by terraform in the github-infra repo.
+# Changes to this CODEOWNERS file should be done in github-infra.
+
+* @HeadspaceMeditation/care-platform

--- a/django_celery_results/admin.py
+++ b/django_celery_results/admin.py
@@ -22,7 +22,7 @@ class TaskResultAdmin(admin.ModelAdmin):
     date_hierarchy = 'date_done'
     list_display = ('task_id', 'task_name', 'date_done', 'status', 'worker')
     list_filter = ('status', 'date_done', 'task_name', 'worker')
-    readonly_fields = ('date_created', 'date_done', 'result', 'meta')
+    readonly_fields = ('date_created', 'date_done', 'meta')
     search_fields = ('task_name', 'task_id', 'status', 'task_args',
                      'task_kwargs')
     fieldsets = (
@@ -46,7 +46,6 @@ class TaskResultAdmin(admin.ModelAdmin):
         }),
         (_('Result'), {
             'fields': (
-                'result',
                 'date_created',
                 'date_done',
                 'traceback',
@@ -66,3 +65,4 @@ class TaskResultAdmin(admin.ModelAdmin):
 
 
 admin.site.register(TaskResult, TaskResultAdmin)
+

--- a/django_celery_results/admin.py
+++ b/django_celery_results/admin.py
@@ -11,7 +11,7 @@ class TaskResultAdmin(admin.ModelAdmin):
 
     model = TaskResult
     list_display = ('task_id', 'date_done', 'status')
-    readonly_fields = ('date_done', 'result', 'hidden', 'meta')
+    readonly_fields = ('date_done', 'hidden', 'meta')
     fieldsets = (
         (None, {
             'fields': (
@@ -24,7 +24,6 @@ class TaskResultAdmin(admin.ModelAdmin):
         }),
         ('Result', {
             'fields': (
-                'result',
                 'date_done',
                 'traceback',
                 'hidden',

--- a/django_celery_results/managers.py
+++ b/django_celery_results/managers.py
@@ -119,7 +119,6 @@ class TaskResultManager(models.Manager):
         """
         fields = {
             'status': status,
-            'result': result,
             'traceback': traceback,
             'meta': meta,
             'content_encoding': content_encoding,
@@ -134,7 +133,8 @@ class TaskResultManager(models.Manager):
         if not created:
             for k, v in fields.items():
                 setattr(obj, k, v)
-            obj.save(using=using)
+        obj.inflated = result
+        obj.save(using=using)
         return obj
 
     def warn_if_repeatable_read(self):
@@ -169,3 +169,4 @@ class TaskResultManager(models.Manager):
         """Delete all expired results."""
         with transaction.atomic():
             self.get_all_expired(expires).delete()
+

--- a/django_celery_results/managers.py
+++ b/django_celery_results/managers.py
@@ -110,7 +110,6 @@ class TaskResultManager(models.Manager):
         """
         fields = {
             'status': status,
-            'result': result,
             'traceback': traceback,
             'meta': meta,
             'content_encoding': content_encoding,
@@ -120,7 +119,8 @@ class TaskResultManager(models.Manager):
         if not created:
             for k, v in items(fields):
                 setattr(obj, k, v)
-            obj.save()
+        obj.inflated = result
+        obj.save()
         return obj
 
     def warn_if_repeatable_read(self):

--- a/django_celery_results/migrations/0001_initial.py
+++ b/django_celery_results/migrations/0001_initial.py
@@ -43,7 +43,7 @@ class Migration(migrations.Migration):
                     max_length=128, verbose_name='content type')),
                 ('content_encoding', models.CharField(
                     max_length=64, verbose_name='content encoding')),
-                ('result', models.TextField(default=None, editable=False,
+                ('result', models.BinaryField(default=None, editable=False,
                                             null=True)),
                 ('date_done', models.DateTimeField(
                     auto_now=True, verbose_name='done at')),

--- a/django_celery_results/migrations/0001_initial.py
+++ b/django_celery_results/migrations/0001_initial.py
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
                     max_length=128, verbose_name='content type')),
                 ('content_encoding', models.CharField(
                     max_length=64, verbose_name='content encoding')),
-                ('result', models.TextField(default=None, editable=False,
+                ('result', models.BinaryField(default=None, editable=False,
                                             null=True)),
                 ('date_done', models.DateTimeField(
                     auto_now=True, verbose_name='done at')),

--- a/django_celery_results/migrations/0004_auto_20190516_0412.py
+++ b/django_celery_results/migrations/0004_auto_20190516_0412.py
@@ -45,7 +45,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='taskresult',
             name='result',
-            field=models.TextField(default=None, editable=False, help_text='The data returned by the task.  Use content_encoding and content_type fields to read.', null=True, verbose_name='Result Data'),
+            field=models.BinaryField(default=None, editable=False, help_text='The data returned by the task.  Use content_encoding and content_type fields to read.', null=True, verbose_name='Result Data'),
         ),
         migrations.AlterField(
             model_name='taskresult',

--- a/django_celery_results/models.py
+++ b/django_celery_results/models.py
@@ -9,6 +9,11 @@ from celery.five import python_2_unicode_compatible
 
 from . import managers
 
+import io
+import gzip
+import logging
+from .utils import disable_logging
+
 ALL_STATES = sorted(states.ALL_STATES)
 TASK_STATE_CHOICES = sorted(zip(ALL_STATES, ALL_STATES))
 
@@ -32,7 +37,10 @@ class TaskResult(models.Model):
     content_encoding = models.CharField(
         _('content encoding'), max_length=64,
     )
-    result = models.TextField(null=True, default=None, editable=False)
+
+    # Warning: access the result via the `inflated` getter/setter which handles gzipping/unzipping,
+    #          do not acccess result data directly.
+    result = models.BinaryField(null=True, default=None, editable=False)
     date_done = models.DateTimeField(_('done at'), auto_now=True)
     traceback = models.TextField(_('traceback'), blank=True, null=True)
     hidden = models.BooleanField(editable=False, default=False, db_index=True)
@@ -50,11 +58,59 @@ class TaskResult(models.Model):
         return {
             'task_id': self.task_id,
             'status': self.status,
-            'result': self.result,
+            'result': self.inflated,
             'date_done': self.date_done,
             'traceback': self.traceback,
             'meta': self.meta,
         }
+
+    @property
+    def inflated(self):
+        """
+        Unzipped result.
+        :return:
+        """
+        if self.result is None:
+            return None
+
+        in_ = io.BytesIO()
+        in_.write(self.result)
+        in_.seek(0)
+        with gzip.GzipFile(fileobj=in_, mode='rb') as fo:
+            gunzipped_bytes_obj = fo.read()
+
+        return gunzipped_bytes_obj.decode('utf-8')
+
+    @inflated.setter
+    def inflated(self, uncompressed):
+        """
+        Gzips the provided uncompressed value into the result field.
+        :param uncompressed: serialized input data
+        :return:
+        """
+        if uncompressed is None:
+            self.result = None
+            return
+
+        # Gzip it for storage.
+        out = io.BytesIO()
+        with gzip.GzipFile(fileobj=out, mode='w') as fo:
+            fo.write(uncompressed.encode('utf-8'))
+        self.result = out.getvalue()
+
+    def save(self, *args, **kwargs):
+        """
+        MySQL django backend issues warnings when BinaryField is sent
+        non text encoded bytes.
+
+        This suppresses these superflous warnings.
+        :param args:
+        :param kwargs:
+        :return:
+        """
+        with disable_logging(logging.WARNING):
+            super(TaskResult, self).save(*args, **kwargs)
+
 
     def __str__(self):
         return '<Task: {0.task_id} ({0.status})>'.format(self)

--- a/django_celery_results/utils.py
+++ b/django_celery_results/utils.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings
 from django.utils import timezone
+import logging
 
 # see Issue celery/django-celery#222
 now_localtime = getattr(timezone, 'template_localtime', timezone.localtime)
@@ -16,3 +17,17 @@ def now():
         return now_localtime(timezone.now())
     else:
         return timezone.now()
+
+class disable_logging(object):
+    """
+    Within block, disable logging at or below the specified level.
+    """
+    def __init__(self, level=logging.WARNING):
+        self.disabled_level = level
+
+    def __enter__(self, *args, **kwargs):
+        logging.disable(self.disabled_level)
+
+    def __exit__(self, *args, **kwargs):
+        logging.disable(logging.NOTSET)
+

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,5 +2,5 @@ case>=1.3.1
 pytest>=4.3
 pytest-django>=2.2,<4.0
 pytest-benchmark
-pytz>dev
+pytz
 psycopg2cffi

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
 case>=1.3.1
 pytest>=3.0
 pytest-django
-pytz>dev
+pytz


### PR DESCRIPTION
https://headspace.atlassian.net/browse/RCM-1022

- Created a `main` branch, and synchronized it with [upstream](https://github.com/celery/django-celery-results) (rev `23265e6c914dc30f8f652dbce098dad6fd761021`), checked out the v2.0.1 tag (4dd32ad7cd165aa69c615b1f6b9243d0d2a0c033) and created a v2.0.1 branch
- branched from that onto v2.0.1-custom and merged our existing changes onto this one

!Important: this requires [celery >=4.4](https://github.com/celery/django-celery-results/blob/v2.0.1/requirements/default.txt)


## Usage
```
django-celery-results = {git = "https://github.com/HeadspaceMeditation/django-celery-results.git", branch = "v2.0.1-custom"}
```